### PR TITLE
Add fix for client and screen-local co-ordinate conversion

### DIFF
--- a/src/main/java/com/chromascape/controller/Controller.java
+++ b/src/main/java/com/chromascape/controller/Controller.java
@@ -60,13 +60,8 @@ public class Controller {
     // Obtain process ID of the target window to initialize input injection
     kinput = new Kinput(WindowHandler.getPid(WindowHandler.getTargetWindow()));
 
-    // Ensure the target window is focused for input simulation
-    ScreenManager.focusWindow();
-    boolean isFullscreen = ScreenManager.isWindowFullscreen();
-
     // Initialize virtual input utilities with current window bounds and fullscreen status
-    virtualMouseUtils =
-        new VirtualMouseUtils(kinput, ScreenManager.getWindowBounds(), isFullscreen);
+    virtualMouseUtils = new VirtualMouseUtils(kinput, ScreenManager.getWindowBounds());
     virtualKeyboardUtils = new VirtualKeyboardUtils(kinput);
 
     // Initialize zone management with fixed mode option

--- a/src/main/java/com/chromascape/utils/core/screen/window/WindowHandler.java
+++ b/src/main/java/com/chromascape/utils/core/screen/window/WindowHandler.java
@@ -47,6 +47,32 @@ public class WindowHandler {
      * @param lpDword Receives the process ID.
      */
     void GetWindowThreadProcessId(HWND hwnd, IntByReference lpDword);
+
+    /**
+     * Enumerates all child windows of a specified parent window.
+     *
+     * <p>This function calls the provided callback {@code lpEnumFunc} for each child window of the
+     * specified parent {@code hWndParent}. It is commonly used to locate specific child controls or
+     * canvases within a larger window.
+     *
+     * @param hwndParent the handle of the parent window whose children are to be enumerated
+     * @param lpEnumFunc the callback function to be called for each child window
+     * @param data a pointer to user-defined data that will be passed to the callback
+     */
+    void EnumChildWindows(HWND hwndParent, WNDENUMPROC lpEnumFunc, Pointer data);
+
+    /**
+     * Retrieves the class name of a specified window.
+     *
+     * <p>This function writes the window class name of {@code hwnd} into the provided byte array
+     * {@code lpString}, up to a maximum of {@code maxCount} characters. It is useful for
+     * identifying specific child windows or controls by class.
+     *
+     * @param hwnd the handle of the window whose class name is to be retrieved
+     * @param lpString the byte array to receive the class name
+     * @param maxCount the maximum number of characters to copy into {@code lpString}
+     */
+    void GetClassNameA(HWND hwnd, byte[] lpString, int maxCount);
   }
 
   /**
@@ -73,6 +99,46 @@ public class WindowHandler {
         null);
 
     return targetHwnd.get(); // May be null if not found
+  }
+
+  /**
+   * Searches for the N-th child window of a given parent window that matches the specified class
+   * name.
+   *
+   * <p>This is useful when multiple child windows share the same class (e.g., RuneLite has two
+   * SunAwtCanvas children: the outer canvas with black bars and the inner canvas with the game
+   * viewport). By specifying an index, you can reliably retrieve the intended child.
+   *
+   * @param parent the {@link HWND} of the parent window whose children are to be enumerated
+   * @param className the class name of the child windows to match (e.g., "SunAwtCanvas")
+   * @param n the 1-based index of the matching child window to retrieve (1 = first match)
+   * @return the {@link HWND} of the N-th matching child window, or {@code null} if no such child
+   *     exists
+   */
+  public static HWND findNthChildWindow(HWND parent, String className, int n) {
+    AtomicReference<HWND> result = new AtomicReference<>();
+    User32 user32 = User32.INSTANCE;
+    int[] count = {0};
+
+    user32.EnumChildWindows(
+        parent,
+        (hwnd, data) -> {
+          byte[] buffer = new byte[512];
+          user32.GetClassNameA(hwnd, buffer, buffer.length);
+          String clsName = Native.toString(buffer).trim();
+
+          if (clsName.equals(className)) {
+            count[0]++;
+            if (count[0] == n) {
+              result.set(hwnd);
+              return false; // stop enumeration
+            }
+          }
+          return true; // continue enumeration
+        },
+        null);
+
+    return result.get(); // may be null if no match found
   }
 
   /**


### PR DESCRIPTION
This PR enhances screenshotting for both Fixed and Resizable-Classic modes by targeting the game-view HWND specifically, rather than the whole window.

- Iterates through child windows of the RuneLite parent to find the correct Canvas.
- Eliminates the need for manual offsets for title bars, side panels, and fullscreen checks.
- Converts points to client coordinates automatically, ensuring click positions align perfectly.
- Removes redundant full screen checks and non-functional calls to bring the client to the foreground.

These changes simplify the code, reduce error-prone calculations, and improve overall accuracy when interacting with the RuneLite client.