### PR TITLE
Fix the script duration overflowing into the next day and exiting

### DIFF
--- a/src/main/java/com/chromascape/base/BaseScript.java
+++ b/src/main/java/com/chromascape/base/BaseScript.java
@@ -4,7 +4,8 @@ import com.chromascape.controller.Controller;
 import com.chromascape.utils.core.runtime.HotkeyListener;
 import com.chromascape.utils.core.runtime.ScriptProgressPublisher;
 import com.chromascape.utils.core.runtime.ScriptStoppedException;
-import java.time.LocalTime;
+import java.time.Duration;
+import java.time.Instant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,7 +24,7 @@ public abstract class BaseScript {
   private static final Logger logger = LogManager.getLogger(BaseScript.class.getName());
   private final HotkeyListener hotkeyListener;
   private boolean running = true;
-  private LocalTime startTime;
+  private Instant startTime;
 
   /**
    * Constructs a BaseScript.
@@ -47,14 +48,14 @@ public abstract class BaseScript {
    * <p>This method blocks until completion.
    */
   public final void run() {
-    startTime = LocalTime.now();
-    LocalTime endTime = startTime.plusMinutes(duration);
+    startTime = Instant.now();
+    Instant endTime = startTime.plus(Duration.ofMinutes(duration));
     logger.info("Starting. Script will run for {} minutes.", duration);
     controller.init();
     hotkeyListener.start();
 
     try {
-      while (running && LocalTime.now().isBefore(endTime)) {
+      while (running && Instant.now().isBefore(endTime)) {
         if (Thread.currentThread().isInterrupted()) {
           logger.info("Thread interrupted, exiting.");
           break;
@@ -106,7 +107,7 @@ public abstract class BaseScript {
     if (startTime == null) {
       return 0;
     }
-    long secondsDone = java.time.Duration.between(startTime, LocalTime.now()).getSeconds();
+    long secondsDone = Duration.between(startTime, Instant.now()).getSeconds();
     long totalSeconds = duration * 60L;
     long clamped = Math.min(secondsDone, totalSeconds);
     return (int) (clamped * 100 / totalSeconds);

--- a/src/main/java/com/chromascape/utils/actions/Idler.java
+++ b/src/main/java/com/chromascape/utils/actions/Idler.java
@@ -5,7 +5,8 @@ import com.chromascape.utils.core.screen.colour.ColourInstances;
 import com.chromascape.utils.core.screen.colour.ColourObj;
 import com.chromascape.utils.domain.ocr.Ocr;
 import java.awt.Rectangle;
-import java.time.LocalTime;
+import java.time.Duration;
+import java.time.Instant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,8 +36,9 @@ public class Idler {
    */
   public static void waitUntilIdle(BaseScript base, int timeoutSeconds) {
     try {
-      LocalTime now = LocalTime.now();
-      while (LocalTime.now().isBefore(now.plusSeconds(timeoutSeconds))) {
+      Instant start = Instant.now();
+      Instant deadline = start.plus(Duration.ofSeconds(timeoutSeconds));
+      while (Instant.now().isBefore(deadline)) {
         Rectangle latestMessage = base.controller().zones().getChatTabs().get("Latest Message");
         ColourObj red = ColourInstances.getByName("ChatRed");
         String ocr = Ocr.extractText(latestMessage, "Plain 12", red, true);
@@ -46,8 +48,7 @@ public class Idler {
         }
       }
     } catch (Exception e) {
-      logger.error(e);
-      logger.error(e.getStackTrace());
+      logger.error("Error while waiting for idle", e);
     }
   }
 }

--- a/src/main/java/com/chromascape/utils/actions/Idler.java
+++ b/src/main/java/com/chromascape/utils/actions/Idler.java
@@ -42,7 +42,6 @@ public class Idler {
         Rectangle latestMessage = base.controller().zones().getChatTabs().get("Latest Message");
         ColourObj red = ColourInstances.getByName("ChatRed");
         String ocr = Ocr.extractText(latestMessage, "Plain 12", red, true);
-        logger.info(ocr);
         if (ocr.contains("idle")) {
           return;
         }


### PR DESCRIPTION
Script duration when set to a high enough number would overflow into the next day. Due to the BaseScript using LocalTime: it would previously roll around to a time less than the current time instead of later.
Also removed a log statement from the idler that was used to debug.