### PR TITLE
Fix comparison in Idler

### DIFF
--- a/src/main/java/com/chromascape/utils/actions/Idler.java
+++ b/src/main/java/com/chromascape/utils/actions/Idler.java
@@ -44,7 +44,7 @@ public class Idler {
         Rectangle latestMessage = base.controller().zones().getChatTabs().get("Latest Message");
         ColourObj red = ColourInstances.getByName("ChatRed");
         String ocr = Ocr.extractText(latestMessage, "Plain 12", red, true);
-        if ((ocr.contains("moving") || ocr.contains("idle")) && ocr != lastMessage) {
+        if ((ocr.contains("moving") || ocr.contains("idle")) && !ocr.equals(lastMessage)) {
           lastMessage = ocr;
           return;
         }


### PR DESCRIPTION
Defensively compare strings using .equals() to ensure that string content is compared.