### PR TITLE
Switch char event to 400 and remove parameter for eventID

### DIFF
--- a/src/main/java/com/chromascape/utils/actions/Idler.java
+++ b/src/main/java/com/chromascape/utils/actions/Idler.java
@@ -28,9 +28,9 @@ public class Idler {
    * Waits until either the specified timeout has elapsed or until the client chatbox reports that
    * the player is idle.
    *
-   * <p>Specifically, this method monitors the "Latest Message" zone in the chatbox for a red message
-   * containing the substring {@code "idle"} or {@code "moving"}, which typically appears when
-   * using the Idle Notifier plugin
+   * <p>Specifically, this method monitors the "Latest Message" zone in the chatbox for a red
+   * message containing the substring {@code "idle"} or {@code "moving"}, which typically appears
+   * when using the Idle Notifier plugin
    *
    * @param base the active {@link BaseScript} instance, usually passed as {@code this}
    * @param timeoutSeconds the maximum number of seconds to remain idle before continuing
@@ -46,7 +46,8 @@ public class Idler {
         ColourObj black = ColourInstances.getByName("Black");
         String idleText = Ocr.extractText(latestMessage, "Plain 12", red, true);
         String timeStamp = Ocr.extractText(latestMessage, "Plain 12", black, true);
-        if ((idleText.contains("moving") || idleText.contains("idle")) && !timeStamp.equals(lastMessage)) {
+        if ((idleText.contains("moving") || idleText.contains("idle"))
+            && !timeStamp.equals(lastMessage)) {
           lastMessage = timeStamp;
           return;
         }

--- a/src/main/java/com/chromascape/utils/core/input/keyboard/VirtualKeyboardUtils.java
+++ b/src/main/java/com/chromascape/utils/core/input/keyboard/VirtualKeyboardUtils.java
@@ -25,12 +25,11 @@ public class VirtualKeyboardUtils {
    * Sends a keyboard event for a character key (e.g., letters, numbers, symbols). Intended for use
    * with regular text input simulation.
    *
-   * @param eventId 401 to simulate a key press, or 402 to simulate a key release.
    * @param keyChar The character key to send.
    */
-  public synchronized void sendKeyChar(int eventId, char keyChar) {
+  public synchronized void sendKeyChar(char keyChar) {
     BaseScript.checkInterrupted();
-    kinput.sendKeyEvent(eventId, keyChar);
+    kinput.sendKeyEvent(400, keyChar);
   }
 
   /**

--- a/src/main/java/com/chromascape/web/instance/WebSocketStateHandler.java
+++ b/src/main/java/com/chromascape/web/instance/WebSocketStateHandler.java
@@ -51,7 +51,7 @@ public class WebSocketStateHandler extends TextWebSocketHandler {
    */
   @Override
   public void afterConnectionClosed(
-          @Nullable WebSocketSession session, @Nullable CloseStatus status) {
+      @Nullable WebSocketSession session, @Nullable CloseStatus status) {
     sessions.remove(session);
   }
 

--- a/src/main/java/com/chromascape/web/logs/WebSocketLogAppender.java
+++ b/src/main/java/com/chromascape/web/logs/WebSocketLogAppender.java
@@ -30,10 +30,10 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
  * @see LogWebSocketHandler
  */
 @Plugin(
-        name = "WebSocketLogAppender",
-        category = "Core",
-        elementType = Appender.ELEMENT_TYPE,
-        printObject = true)
+    name = "WebSocketLogAppender",
+    category = "Core",
+    elementType = Appender.ELEMENT_TYPE,
+    printObject = true)
 public class WebSocketLogAppender extends AbstractAppender {
 
   /**


### PR DESCRIPTION
- Previously, I had mistaken KeyChar events to be 401 to open and 402 to close.
- It is in fact 400 and there is no reason to close it.
- Any whitespace related changes are due to spotless.